### PR TITLE
Fix woodcutter npc settings not initializing

### DIFF
--- a/scripts/NPCs/Woodcutter.ts
+++ b/scripts/NPCs/Woodcutter.ts
@@ -379,6 +379,10 @@ export class Woodcutter extends NPC{
 
             // Set the state (will set the Entity property nox:state_enum) to the currently loaded state in memory
             this.SetState(this.State);
+
+            // Initialize the dialog for the woodcutter
+            this.Entity.setProperty("nox:dialog_initiated", true);
+            this.InitDialog();
         }
     }
 

--- a/scripts/NPCs/Woodcutter.ts
+++ b/scripts/NPCs/Woodcutter.ts
@@ -157,7 +157,7 @@ export class Woodcutter extends NPC{
             if (dialogInitiated !== undefined){
                 Debug.Info("Checking dialog initiated");
                 let dialogInitiatedBool: boolean = <boolean>dialogInitiated;
-                console.warn(dialogInitiatedBool);
+                
                 if (!dialogInitiatedBool){
                     Debug.Info("Initiating woodcutter dialog.");
                     entity.setProperty("nox:dialog_initiated", true);


### PR DESCRIPTION
The NPC's dialog settings would only work when you re-load the game after it was placed.

This fixes it by running InitDialog() on the woodcutter when it is initially spawned.