### PR TITLE
Add Item-Tagged Mining Speeds to Custom Blocks

### DIFF
--- a/behavior-pack/blocks/npc-management-table.json
+++ b/behavior-pack/blocks/npc-management-table.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.20.50",
+    "format_version": "1.21.60",
     "minecraft:block": {
         "description": {
             "identifier": "nox:npc-management-table",
@@ -47,11 +47,17 @@
             }
         ],
         "components": {
-            "minecraft:destructible_by_mining":{
-                "seconds_to_destroy": 2
-            },
             "minecraft:geometry":{
                 "identifier": "geometry.nox.npc-management-table"
+            },
+            "minecraft:destructible_by_mining":{
+                "seconds_to_destroy": 1.0,
+                "item_specific_speeds": [
+                    {
+                        "item": { "tags" : "q.any_tag('minecraft:is_axe')"},
+                        "destroy_speed": 0.25
+                    }
+                ]
             },
             "minecraft:crafting_table": {
                 "crafting_tags": ["nox:npc-management-table"],

--- a/behavior-pack/blocks/woodcutter-manager.json
+++ b/behavior-pack/blocks/woodcutter-manager.json
@@ -1,5 +1,5 @@
 {
-    "format_version": "1.20.50",
+    "format_version": "1.21.60",
     "minecraft:block": {
         "description": {
             "identifier": "nox:woodcutter-manager",
@@ -10,16 +10,25 @@
             }
         },
         "components": {
-            "tag:wood":{},
             "minecraft:geometry":{
                 "identifier": "geometry.nox.woodcutter-manager"
+            },
+            "minecraft:destructible_by_mining":{
+                "seconds_to_destroy": 1.0,
+                "item_specific_speeds": [
+                    {
+                        "item": { "tags" : "q.any_tag('minecraft:is_axe')"},
+                        "destroy_speed": 0.25
+                    }
+                ]
             },
             "minecraft:material_instances": {
                 "*": {
                     "texture": "nox-woodcutter-manager",
                     "render_method": "opaque"
                 }
-            }
+            },
+            "tag:wood":{}
         }
     }
 }


### PR DESCRIPTION
- The Woodcutter Manager could be instant mined with your hands
- The NPC Management Table took forever to mine

Both now can be broken within a second or two, but faster with an axe.